### PR TITLE
Using / for paths on Windows does not work

### DIFF
--- a/src/main/scala/net/ground5hark/sbt/concat/SbtConcat.scala
+++ b/src/main/scala/net/ground5hark/sbt/concat/SbtConcat.scala
@@ -76,7 +76,9 @@ object SbtConcat extends AutoPlugin {
         groupsValue.foreach {
           case (groupName, fileNames) =>
             fileNames.foreach { fileName =>
-              val mapping = filteredMappings.filter(_._2 == fileName)
+              val separator = File.separatorChar
+              def normalize(path: String) = path.replace('\\', separator).replace('/', separator)
+              val mapping = filteredMappings.filter(entry => normalize(entry._2) == normalize(fileName))
               if (mapping.nonEmpty) {
                 // TODO This is not as memory efficient as it could be, write to file instead
                 concatGroups.getOrElseUpdate(groupName, new StringBuilder)

--- a/src/main/scala/net/ground5hark/sbt/concat/SbtConcat.scala
+++ b/src/main/scala/net/ground5hark/sbt/concat/SbtConcat.scala
@@ -6,6 +6,7 @@ import sbt._
 import com.typesafe.sbt.web.pipeline.Pipeline
 import collection.mutable
 import mutable.ListBuffer
+import java.io.File
 
 object Import {
   val concat = TaskKey[Pipeline.Stage]("web-concat", "Concatenates groups of web assets")


### PR DESCRIPTION
If we use "js/script1.js" on windows it won't find the file in a mapping (silently =(, I suggest giving a warning here), since file in a mapping uses "\" as dir separator