### PR TITLE
Add warning messages for unmapped files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Concat.groups := Seq(
 Note that with a `PathFinder`, you will need to take care to ensure that the files it selects will be concatenated in
 the order that you desire.
 
+To match entries in `Seq[String]` in group `PathMapping` is used. Only relative paths up to one level deep are guaranteed match.
+
 This will produce three files with concatenated contents:
 
 `style-group.css`

--- a/src/main/scala/net/ground5hark/sbt/concat/SbtConcat.scala
+++ b/src/main/scala/net/ground5hark/sbt/concat/SbtConcat.scala
@@ -83,7 +83,7 @@ object SbtConcat extends AutoPlugin {
                   .append(s"\n/** $fileName **/\n")
                   .append(IO.read(mapping.head._1))
                 reverseMapping.remove(fileName)
-              }
+              } else streams.value.log.warn(s"Unable to process $fileName. Not found.")
             }
         }
 


### PR DESCRIPTION
Pull request to fix: https://github.com/ground5hark/sbt-concat/issues/22

Background on one level deep relative paths which relates to my update of the README. 

This was something that bit me quite bad. `PathMapping` according to the documentation on the SbtWeb README produces one level of relative path in the second element in the `PathMapping`-tuple, ie. `(a/b/c -> b/c)`. Problem is that in practice this that is not consistent. 

After debugging I found that there were relative path mappings several levels deep in my `target/web/stage` directory but not for resources from the `assets` directory. 

So when I concatenated un-minified files (dev) it worked fine but not when I tried to match agains the minified filed produced by `sbt-closure`, because there only one level of relative paths were mapped.